### PR TITLE
Added Python 3 support

### DIFF
--- a/src/x86_64-fma/2d-fourier-16x16.py
+++ b/src/x86_64-fma/2d-fourier-16x16.py
@@ -1,3 +1,6 @@
+from __future__ import absolute_import
+from __future__ import division
+
 import fft16x16
 import fft.complex_soa
 import fft.two_real_to_two_complex_soa_perm_planar

--- a/src/x86_64-fma/2d-fourier-8x8.py
+++ b/src/x86_64-fma/2d-fourier-8x8.py
@@ -1,9 +1,12 @@
+from __future__ import absolute_import
+from __future__ import division
+
+import block8x8
 import fft.complex_soa
 import fft.real_to_complex_soa_perm
 import fft.complex_soa_perm_to_real
 import fft.two_real_to_two_complex_soa_perm_planar
 import fft.two_complex_soa_perm_to_two_real_planar
-import block8x8
 
 
 arg_t_pointer = Argument(ptr(const_float_), name="t_pointer")

--- a/src/x86_64-fma/2d-winograd-8x8-3x3.py
+++ b/src/x86_64-fma/2d-winograd-8x8-3x3.py
@@ -1,3 +1,6 @@
+from __future__ import absolute_import
+from __future__ import division
+
 import winograd.o6x6k3x3
 import block8x8
 from common import _MM_SHUFFLE

--- a/src/x86_64-fma/blas/c8gemm.py
+++ b/src/x86_64-fma/blas/c8gemm.py
@@ -1,3 +1,6 @@
+from __future__ import absolute_import
+from __future__ import division
+
 mr, nr = 2, 2
 
 for conjugate_b, transpose_c in [(False, False), (True, False), (True, True)]:

--- a/src/x86_64-fma/blas/conv1x1.py
+++ b/src/x86_64-fma/blas/conv1x1.py
@@ -1,3 +1,6 @@
+from __future__ import absolute_import
+from __future__ import division
+
 mr, nr = 2, 4
 
 arg_input_channels = Argument(size_t, "input_channels")

--- a/src/x86_64-fma/blas/s4c6gemm.py
+++ b/src/x86_64-fma/blas/s4c6gemm.py
@@ -1,3 +1,6 @@
+from __future__ import absolute_import
+from __future__ import division
+
 mr, nr = 2, 2
 
 for conjugate_b, transpose_c in [(False, False), (True, False), (True, True)]:

--- a/src/x86_64-fma/blas/s8gemm.py
+++ b/src/x86_64-fma/blas/s8gemm.py
@@ -1,3 +1,6 @@
+from __future__ import absolute_import
+from __future__ import division
+
 mr, nr = 3, 4
 
 arg_k = Argument(size_t, "k")

--- a/src/x86_64-fma/blas/sdotxf.py
+++ b/src/x86_64-fma/blas/sdotxf.py
@@ -1,4 +1,7 @@
-simd_width = YMMRegister.size / float_.size
+from __future__ import absolute_import
+from __future__ import division
+
+simd_width = YMMRegister.size // float_.size
 
 for fusion_factor in range(1, 8 + 1):
 	arg_x = Argument(ptr(const_float_), "x")
@@ -35,7 +38,7 @@ for fusion_factor in range(1, 8 + 1):
 		main_loop = Loop()
 		end_block = Block()
 
-		SUB(reg_n, YMMRegister.size / float_.size)
+		SUB(reg_n, YMMRegister.size // float_.size)
 		JB(main_loop.end)
 
 		with main_loop:
@@ -47,10 +50,10 @@ for fusion_factor in range(1, 8 + 1):
 				VFMADD231PS(ymm_acc, ymm_x, [reg_y])
 				ADD(reg_y, YMMRegister.size)
 
-			SUB(reg_n, YMMRegister.size / float_.size)
+			SUB(reg_n, YMMRegister.size // float_.size)
 			JAE(main_loop.begin)
 
-		ADD(reg_n, YMMRegister.size / float_.size)
+		ADD(reg_n, YMMRegister.size // float_.size)
 		JE(end_block.end)
 
 		with end_block:

--- a/src/x86_64-fma/blas/sgemm.py
+++ b/src/x86_64-fma/blas/sgemm.py
@@ -1,6 +1,9 @@
+from __future__ import absolute_import
+from __future__ import division
+
 from common import _MM_SHUFFLE
 
-simd_width = YMMRegister.size / float_.size
+simd_width = YMMRegister.size // float_.size
 mr = 4
 nr = 3 * simd_width
 

--- a/src/x86_64-fma/blas/shdotxf.py
+++ b/src/x86_64-fma/blas/shdotxf.py
@@ -1,7 +1,10 @@
+from __future__ import absolute_import
+from __future__ import division
+
 from fp16.avx import fp16_alt_xmm_to_fp32_xmm
 from fp16.avx2 import fp16_alt_xmm_to_fp32_ymm
 
-simd_width = YMMRegister.size / float_.size
+simd_width = YMMRegister.size // float_.size
 
 for fusion_factor in range(1, 8 + 1):
 	arg_x = Argument(ptr(const_float_), "x")
@@ -38,7 +41,7 @@ for fusion_factor in range(1, 8 + 1):
 		main_loop = Loop()
 		edge_loop = Loop()
 
-		SUB(reg_n, XMMRegister.size / uint16_t.size)
+		SUB(reg_n, XMMRegister.size // uint16_t.size)
 		JB(main_loop.end)
 
 		with main_loop:
@@ -54,10 +57,10 @@ for fusion_factor in range(1, 8 + 1):
 				ymm_y = fp16_alt_xmm_to_fp32_ymm(xmm_half)
 				VFMADD231PS(ymm_acc, ymm_x, ymm_y)
 
-			SUB(reg_n, YMMRegister.size / float_.size)
+			SUB(reg_n, YMMRegister.size // float_.size)
 			JAE(main_loop.begin)
 
-		ADD(reg_n, XMMRegister.size / uint16_t.size)
+		ADD(reg_n, XMMRegister.size // uint16_t.size)
 		JE(edge_loop.end)
 
 		with edge_loop:

--- a/src/x86_64-fma/block8x8.py
+++ b/src/x86_64-fma/block8x8.py
@@ -1,3 +1,6 @@
+from __future__ import absolute_import
+from __future__ import division
+
 from peachpy import *
 from peachpy.x86_64 import *
 

--- a/src/x86_64-fma/blockmac.py
+++ b/src/x86_64-fma/blockmac.py
@@ -1,3 +1,6 @@
+from __future__ import absolute_import
+from __future__ import division
+
 from peachpy import *
 from peachpy.x86_64 import *
 

--- a/src/x86_64-fma/common.py
+++ b/src/x86_64-fma/common.py
@@ -1,3 +1,6 @@
+from __future__ import absolute_import
+from __future__ import division
+
 from peachpy import *
 from peachpy.x86_64 import *
 

--- a/src/x86_64-fma/exp.py
+++ b/src/x86_64-fma/exp.py
@@ -1,3 +1,6 @@
+from __future__ import absolute_import
+from __future__ import division
+
 from peachpy import *
 from peachpy.x86_64 import *
 

--- a/src/x86_64-fma/fft-aos.py
+++ b/src/x86_64-fma/fft-aos.py
@@ -1,3 +1,6 @@
+from __future__ import absolute_import
+from __future__ import division
+
 import fft.complex_soa
 
 arg_t = Argument(ptr(const_float_), name="t")

--- a/src/x86_64-fma/fft-block-mac.py
+++ b/src/x86_64-fma/fft-block-mac.py
@@ -1,3 +1,6 @@
+from __future__ import absolute_import
+from __future__ import division
+
 from blockmac import multiply_accumulate_complex_aos_perm
 
 arg_acc = Argument(ptr(float_), name="acc")

--- a/src/x86_64-fma/fft/complex_soa.py
+++ b/src/x86_64-fma/fft/complex_soa.py
@@ -1,11 +1,12 @@
+from __future__ import absolute_import
+from __future__ import division
+
 from peachpy import *
 from peachpy.x86_64 import *
-
 
 from common import cos_npi_over_8, sin_npi_over_8, cos_npi_over_4, sin_npi_over_4
 from common import _MM_SHUFFLE
 from common import butterfly, transpose2x2x128, transpose2x2x2x64, interleave
-
 
 def fft8_within_rows(ymm_real_rows, ymm_imag_rows, transformation="forward"):
     if isinstance(ymm_real_rows, YMMRegister) and isinstance(ymm_imag_rows, YMMRegister):

--- a/src/x86_64-fma/fft/complex_soa_perm_to_real.py
+++ b/src/x86_64-fma/fft/complex_soa_perm_to_real.py
@@ -1,11 +1,13 @@
+from __future__ import absolute_import
+from __future__ import division
+
 from peachpy import *
 from peachpy.x86_64 import *
 
 from common import sqrt2_over_2
 from common import butterfly
 
-import complex_soa
-
+import fft.complex_soa
 
 def ifft8_across_rows(ymm_data, bias=None):
     assert isinstance(ymm_data, list) and len(ymm_data) == 8
@@ -62,7 +64,7 @@ def ifft8_across_rows(ymm_data, bias=None):
     VFMSUB231PS(ymm_g1_imag, ymm_h1_minus, ymm_sqrt2_over_2)
     SWAP.REGISTERS(ymm_imag[3], ymm_g1_imag)
 
-    complex_soa.fft4_across_rows(ymm_real, ymm_imag, transformation="inverse")
+    fft.complex_soa.fft4_across_rows(ymm_real, ymm_imag, transformation="inverse")
 
     if bias is not None:
         ymm_bias = bias

--- a/src/x86_64-fma/fft/real_to_complex_soa_perm.py
+++ b/src/x86_64-fma/fft/real_to_complex_soa_perm.py
@@ -1,10 +1,13 @@
+from __future__ import absolute_import
+from __future__ import division
+
 from peachpy import *
 from peachpy.x86_64 import *
 
 from common import sqrt2_over_2
 from common import butterfly
 
-import complex_soa
+import fft.complex_soa
 
 
 def fft8_across_rows(ymm_data):
@@ -12,7 +15,7 @@ def fft8_across_rows(ymm_data):
     ymm_real = ymm_data[0::2]
     ymm_imag = ymm_data[1::2]
 
-    complex_soa.fft4_across_rows(ymm_real, ymm_imag)
+    fft.complex_soa.fft4_across_rows(ymm_real, ymm_imag)
 
     butterfly(ymm_real[0], ymm_imag[0])
 

--- a/src/x86_64-fma/fft/two_complex_soa_perm_to_two_real_planar.py
+++ b/src/x86_64-fma/fft/two_complex_soa_perm_to_two_real_planar.py
@@ -1,3 +1,6 @@
+from __future__ import absolute_import
+from __future__ import division
+
 from peachpy import *
 from peachpy.x86_64 import *
 

--- a/src/x86_64-fma/fft/two_real_to_two_complex_soa_perm_planar.py
+++ b/src/x86_64-fma/fft/two_real_to_two_complex_soa_perm_planar.py
@@ -1,3 +1,6 @@
+from __future__ import absolute_import
+from __future__ import division
+
 from peachpy import *
 from peachpy.x86_64 import *
 

--- a/src/x86_64-fma/fft16x16.py
+++ b/src/x86_64-fma/fft16x16.py
@@ -1,3 +1,6 @@
+from __future__ import absolute_import
+from __future__ import division
+
 from peachpy import *
 from peachpy.x86_64 import *
 from common import butterfly, sqrt2_over_2

--- a/src/x86_64-fma/relu.py
+++ b/src/x86_64-fma/relu.py
@@ -40,7 +40,7 @@ with Function("nnp_relu__avx2",
 		VMOVNTPS([reg_output], ymm_data)
 		ADD(reg_output, YMMRegister.size)
 
-		SUB(reg_length, YMMRegister.size / float_.size)
+		SUB(reg_length, YMMRegister.size // float_.size)
 		JNZ(loop.begin)
 
 	RETURN()
@@ -83,7 +83,7 @@ with Function("nnp_inplace_relu__avx2",
 		VMOVAPS([reg_data], ymm_data)
 		ADD(reg_data, YMMRegister.size)
 
-		SUB(reg_length, YMMRegister.size / float_.size)
+		SUB(reg_length, YMMRegister.size // float_.size)
 		JNZ(loop.begin)
 
 	RETURN()
@@ -140,7 +140,7 @@ with Function("nnp_grad_relu__avx2",
 		VMOVAPS([reg_input_gradient], ymm_gradient)
 		ADD(reg_input_gradient, YMMRegister.size)
 
-		SUB(reg_length, YMMRegister.size / float_.size)
+		SUB(reg_length, YMMRegister.size // float_.size)
 		JNZ(loop.begin)
 
 	RETURN()

--- a/src/x86_64-fma/softmax.py
+++ b/src/x86_64-fma/softmax.py
@@ -17,7 +17,7 @@ with Function("max__avx", (arg_n, arg_v), float_,
     vector_loop = Loop()
     final_block = Block()
 
-    simd_width = YMMRegister.size / float_.size
+    simd_width = YMMRegister.size // float_.size
     unroll_factor = 4
 
     # Initialize reduction registers with the first element (v[0])
@@ -105,7 +105,7 @@ with Function("sum_exp_minus_c__avx2", (arg_n, arg_v, arg_c), float_,
     vector_loop = Loop()
     final_block = Block()
 
-    simd_width = YMMRegister.size / float_.size
+    simd_width = YMMRegister.size // float_.size
     unroll_factor = 3
 
     # Clear reduction registers
@@ -190,7 +190,7 @@ def scaled_exp_minus_c(reg_n, reg_x, reg_y, ymm_scale, ymm_c):
     vector_loop = Loop()
     final_block = Block()
 
-    simd_width = YMMRegister.size / float_.size
+    simd_width = YMMRegister.size // float_.size
     unroll_factor = 3
 
     # Unrolled vectorized loop

--- a/src/x86_64-fma/vecmath/exp.py
+++ b/src/x86_64-fma/vecmath/exp.py
@@ -1,3 +1,6 @@
+from __future__ import absolute_import
+from __future__ import division
+
 from peachpy import *
 from peachpy.x86_64 import *
 

--- a/src/x86_64-fma/winograd/o6x6k3x3.py
+++ b/src/x86_64-fma/winograd/o6x6k3x3.py
@@ -1,3 +1,7 @@
+from __future__ import absolute_import
+from __future__ import division
+
+
 from peachpy import *
 from peachpy.x86_64 import *
 


### PR DESCRIPTION
This patch would enable Python 3 support for NNPACK:
- Use integer division instead of true division in Python3
- Use explicit relative imports than implicit ones