### PR TITLE
Pooling: fix documentation

### DIFF
--- a/include/nnpack.h
+++ b/include/nnpack.h
@@ -474,10 +474,10 @@ enum nnp_status nnp_fully_connected_inference_f16f32(
  * @param[out] output A 4D tensor output[batch_size][channels][output_size.height][output_size.width] where
  *                    output_size.height = ceil(
  *                      (input_padding.top + input_size.height + input_padding.bottom - pooling_size.height) /
- *                        pooling_stride.height)
+ *                        pooling_stride.height) + 1
  *                    output_size.width = ceil(
  *                      (input_padding.left + input_size.width + input_padding.right - pooling_size.width) /
- *                        pooling_stride.width)
+ *                        pooling_stride.width) + 1
  * @param threadpool A thread pool for parallelization of the computation.
  *                   If threadpool is NULL, the computation would run on the caller thread without parallelization.
  */


### PR DESCRIPTION
It seems the output size of the pooling operation was incorrectly documented.