### PR TITLE
Android: fix ARMv7 builds

### DIFF
--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -106,6 +106,7 @@ endif # TARGET_ARCH_ABI is x86, x86-64, armeabi-v7a, or arm64-v8a
 LOCAL_CFLAGS := -std=gnu99 -D__STDC_CONSTANT_MACROS=1
 ifeq ($(TARGET_ARCH_ABI),armeabi-v7a)
 LOCAL_ARM_NEON := true
+LOCAL_CFLAGS += -mfpu=neon-fp16
 endif # TARGET_ARCH_ABI == armeabi-v7a
 include $(BUILD_STATIC_LIBRARY)
 


### PR DESCRIPTION
This patch could fix the following error when cross-compilation for Android (armeabi-v7a) with `ndk-build`.

In file included from jni/../jni/../src/neon/winograd-f6k3.c:1:
In file included from jni/../src/neon/winograd/f6x6k3x3.h:5:
jni/../include/nnpack/arm_neon.h:26:10: warning: implicit declaration of function 'vcvt_f32_f16' is invalid in C99 [-Wimplicit-function-declaration]
                return vcvt_f32_f16(vld1_f16((const __fp16*) address));
                       ^
jni/../include/nnpack/arm_neon.h:26:10: error: returning 'int' from a function with incompatible result type 'float32x4_t' (vector of 4 'float32_t' values)
                return vcvt_f32_f16(vld1_f16((const __fp16*) address));
                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
jni/../include/nnpack/arm_neon.h:30:10: error: returning 'int' from a function with incompatible result type 'float32x4_t' (vector of 4 'float32_t' values)
                return vcvt_f32_f16(vld1_f16((const __fp16*)
                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
jni/../include/nnpack/arm_neon.h:35:31: warning: implicit declaration of function 'vcvt_f16_f32' is invalid in C99 [-Wimplicit-function-declaration]
                vst1_f16((__fp16*) address, vcvt_f16_f32(vector));
                                            ^
jni/../include/nnpack/arm_neon.h:35:3: error: initializing 'float16x4_t' (vector of 4 'float16_t' values) with an expression of incompatible type 'int'
                vst1_f16((__fp16*) address, vcvt_f16_f32(vector));
                ^                           ~~~~~~~~~~~~~~~~~~~~
/home/mtk08168/android-ndk-r15c/toolchains/llvm/prebuilt/linux-x86_64/lib64/clang/5.0.300080/include/arm_neon.h:25224:15: note: expanded from macro 'vst1_f16'
  float16x4_t __s1 = __p1; \
              ^      ~~~~
In file included from jni/../jni/../src/neon/winograd-f6k3.c:1:
In file included from jni/../src/neon/winograd/f6x6k3x3.h:5:
jni/../include/nnpack/arm_neon.h:39:3: error: initializing 'float16x4_t' (vector of 4 'float16_t' values) with an expression of incompatible type 'int'
                vst1_f16((__fp16*) __builtin_assume_aligned(address, sizeof(float16x4_t)),
                ^
/home/mtk08168/android-ndk-r15c/toolchains/llvm/prebuilt/linux-x86_64/lib64/clang/5.0.300080/include/arm_neon.h:25224:15: note: expanded from macro 'vst1_f16'
  float16x4_t __s1 = __p1; \
              ^      ~~~~
2 warnings and 4 errors generated.
make: *** [obj/local/armeabi-v7a/objs/nnpack_test_ukernels/jni/__/src/neon/winograd-f6k3.o] Error 1