### PR TITLE
Fix x86 32 bit detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 CMAKE_MINIMUM_REQUIRED(VERSION 2.8.12 FATAL_ERROR)
 
 INCLUDE(GNUInstallDirs)
+INCLUDE(CheckCSourceCompiles)
 
 # ---[ Project and semantic versioning.
 PROJECT(NNPACK C CXX ASM)
@@ -78,6 +79,18 @@ IF(NNPACK_BACKEND STREQUAL "auto")
 ENDIF()
 
 IF(NNPACK_BACKEND STREQUAL "x86-64")
+  # ---[ CMAKE_SYSTEM_PROCESSOR will show x86_64 when we're compiling on 32 bit systems on 64 bit cpus
+  CHECK_C_SOURCE_COMPILES("
+     #if ! (defined(__i386) || defined(_M_IX86))
+       #error AVX only on x86_64
+      #endif
+      int main() {
+        return 0;
+      }" NNPACK_ARCH_IS_X86_32)
+  IF(NNPACK_ARCH_IS_X86_32)
+    MESSAGE(STATUS "compiling for x86_32 on a 64bit machine, use to PSIMD backend")
+    SET(NNPACK_BACKEND "psimd")
+  ENDIF()
   # ---[ We need a Python interpreter to build PeachPy sources for x86-64
   FIND_PACKAGE(PythonInterp)
   IF(NOT PYTHONINTERP_FOUND)
@@ -85,6 +98,8 @@ IF(NNPACK_BACKEND STREQUAL "x86-64")
     SET(NNPACK_BACKEND "psimd")
   ENDIF()
 ENDIF()
+
+MESSAGE(STATUS "NNPACK backend is ${NNPACK_BACKEND}")
 
 # ---[ Download deps
 SET(CONFU_DEPENDENCIES_SOURCE_DIR ${CMAKE_SOURCE_DIR}/deps

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,21 @@ IF(NNPACK_BACKEND STREQUAL "auto")
     MESSAGE(WARNING "CMAKE_SYSTEM_PROCESSOR is not defined, using PSIMD backend")    
     SET(NNPACK_BACKEND "psimd")
   ELSEIF(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64" AND NOT CMAKE_SYSTEM_NAME STREQUAL "Android")
-    SET(NNPACK_BACKEND "x86-64")
+    # ---[ CMAKE_SYSTEM_PROCESSOR will show x86_64 when we're compiling on 32 bit systems on 64 bit cpus
+    CHECK_C_SOURCE_COMPILES("
+      #if ! (defined(__i386) || defined(_M_IX86))
+        #error AVX only on x86_64
+      #endif
+      int main() {
+        return 0;
+      }" NNPACK_ARCH_IS_X86_32)
+    IF(NNPACK_ARCH_IS_X86_32)
+      MESSAGE(STATUS "compiling for x86_32 on a 64bit machine, use to PSIMD backend")
+      SET(NNPACK_BACKEND "psimd")
+    ELSE()
+      # ---[ now we know it is a "real" x86-64 system
+      SET(NNPACK_BACKEND "x86-64")
+    ENDIF()
   ELSEIF(CMAKE_SYSTEM_PROCESSOR MATCHES "^(armv5te|armv7-a|armv7l|aarch64)$")
     SET(NNPACK_BACKEND "neon")
   ELSE()
@@ -79,18 +93,6 @@ IF(NNPACK_BACKEND STREQUAL "auto")
 ENDIF()
 
 IF(NNPACK_BACKEND STREQUAL "x86-64")
-  # ---[ CMAKE_SYSTEM_PROCESSOR will show x86_64 when we're compiling on 32 bit systems on 64 bit cpus
-  CHECK_C_SOURCE_COMPILES("
-     #if ! (defined(__i386) || defined(_M_IX86))
-       #error AVX only on x86_64
-      #endif
-      int main() {
-        return 0;
-      }" NNPACK_ARCH_IS_X86_32)
-  IF(NNPACK_ARCH_IS_X86_32)
-    MESSAGE(STATUS "compiling for x86_32 on a 64bit machine, use to PSIMD backend")
-    SET(NNPACK_BACKEND "psimd")
-  ENDIF()
   # ---[ We need a Python interpreter to build PeachPy sources for x86-64
   FIND_PACKAGE(PythonInterp)
   IF(NOT PYTHONINTERP_FOUND)


### PR DESCRIPTION
When building on 32bit linux ("i386" architecture) on a 64 bit machine, cmake will report CMAKE_SYSTEM_PROCESSOR as x86_64 - which is not intended. This currently causes NNPACK to detect x86-64 target when the psimd would be correct - the result is a mix of x86_64 and x86 object files and unhappy linkers.
This patch checks the pre-defined architecture macros for x86_32 and sets the backend to psimd if x86_32 is detected.
Compared to the ill-fated #161 it should leave x32 alone.
